### PR TITLE
Add OpenGraph and Twitter Card metadata to HTML head

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# macOS leftovers
+.DS_Store
+
 # Node.js-related assets (e.g. for CSS)
 node_modules/
 

--- a/config.toml
+++ b/config.toml
@@ -5,6 +5,7 @@ pygmentsUseClasses = true
 pygmentsCodefences = true
 
 [params]
+description        = "An industry-standard container runtime with an emphasis on simplicity, robustness, and portability"
 googleAnalyticsId  = "UA-71407002-1"
 githubRepo         = "containerd/containerd"
 twitterHandle      = "containerd"

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,3 +1,40 @@
+{{- $isHome        := .IsHome }}
+{{- $isDoc         := eq .Section "docs" }}
+{{- $title         := cond $isHome .Site.Title (printf "%s &ndash; %s" .Site.Title .Title) }}
+{{- $description   := cond $isHome .Site.Params.description .Params.description }}
+{{- $pageType      := cond $isHome "website" "article" }}
+{{- $imageUrl      := "img/logos/horizontal/color/containerd-horizontal-color.png" | absURL }}
+{{- $twitterHandle := .Site.Params.twitterHandle }}
 <meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="viewport" content="initial-scale=1,maximum-scale=1,user-scalable=no" />
+{{- with $description }}
+<meta name="description" content="{{ . }}" />
+{{- end }}
+
+<!-- OpenGraph metadata-->
+<meta property="og:title" content="{{ $title }}">
+{{- if $isDoc }}
+<meta property="og:type" content="documentation">
+{{- end }}
+<meta property="og:url" content="{{ .Permalink }}">
+<meta property="og:locale" content="en_US">
+{{- if not $isHome }}
+<meta property="og:site_name" content="{{ .Site.Title }}">
+{{- end }}
+{{- with $description }}
+<meta property="og:description" content="{{ . }}">
+{{- end }}
+<meta name="og:type" content="{{ $pageType }}">
+<meta name="og:image" content="{{ $imageUrl }}">
+<meta name="og:image:alt" content="containerd project logo">
+<meta name="og:image:type" content="image/png">
+
+
+<!-- Twitter Card metadata -->
+<meta name="twitter:card" content="summary">
+<meta name="twitter:site" content="@{{ $twitterHandle }}">
+<meta name="twitter:creator" content="@{{ $twitterHandle }}">
+
+<link rel="canonical" content="{{ .Permalink }}">
 <link rel="shortcut icon" href="/favicon.png" type="image/png">
+{{ .Hugo.Generator }}


### PR DESCRIPTION
This PR adds some basic SEO stuff for Facebook's OpenGraph and Twitter Cards. This will be essential to search engine discoverability.