### PR TITLE
Site configuration update

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,10 @@
-baseURL = "/"
+baseURL = "https://containerd.io"
 languageCode = "en-us"
 title = "containerd"
 pygmentsUseClasses = true
 pygmentsCodefences = true
+enableRobotsTXT = true
+disableKinds = ["taxonomy", "taxonomyTerm"]
 
 [params]
 googleAnalyticsId  = "UA-71407002-1"


### PR DESCRIPTION
This PR encompasses a small handful of config updates for the site:

* Sets the `baseURL`, which will make the sitemap render correctly
* Enables the addition of a [`robots.txt`](https://deploy-preview-13--containerd-io.netlify.com/robots.txt) to the site
* Disables the creation of content taxonomies (we may use these later but for now they just generate unused files)