### PR TITLE
Replace repo name for containerd

### DIFF
--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -1,4 +1,4 @@
-- name: container
+- name: containerd
   description: The main project repo for containerd, including the container runtime
 - name: containerd.io
   description: Assets used to build the containerd website and documentation (i.e. what you're currently reading)


### PR DESCRIPTION
Hi

The repo name for containerd seems to be bad on https://containerd.io/docs/

Cheers