### PR TITLE
Update copyright year and latest release

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -32,7 +32,7 @@ features = [
 ]
 
 [params.versions]
-latest = "1.2.0"
+latest = "1.2.1"
 
 [[params.fonts]]
 name = "Lato"


### PR DESCRIPTION
The copyright year is a var in the footer partial, but need a Hugo
run/deploy to get it updated to 2019. Also, latest release is now
containerd 1.2.1

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>