### PR TITLE
Add link to containerd project branding page

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -62,6 +62,10 @@
               {{ .Title }}
             </a>
             {{- end }}
+
+            <a class="navbar-item" href="https://branding.cncf.io/projects/containerd">
+              containerd branding
+            </a>
           </div>
         </div> <!-- .navbar-item -->
 


### PR DESCRIPTION
This PR adds a link to the new CNCF project branding site: https://branding.cncf.io/projects/containerd/