### PR TITLE
Remove invalid links when copying in markdown

### DIFF
--- a/.github/workflows/sync-releases.yml
+++ b/.github/workflows/sync-releases.yml
@@ -14,6 +14,9 @@ jobs:
         run: |
           curl -o content/releases.md https://raw.githubusercontent.com/containerd/containerd/master/RELEASES.md
           sed -i'' 's,^# Versioning and Release$,---\ntitle: Versioning and release\n---,' content/releases.md
+          sed -i'' 's,| \[api/\](api),| \[gRPC API\](#grpc),' content/releases.md
+          sed -i'' 's,See \[api/\](api) for details.,,' content/releases.md
+          sed -i'' 's,^### GRPC API,### GRPC API {#grpc},' content/releases.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v2
         with:


### PR DESCRIPTION
This could become brittle, but for now seems like a reasonable quick fix
to not have dead links in the copied-in releases.md from the main
containerd repository.

// cc: @lucperkins per discussion in #53 

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>