### PR TITLE
Switch to GitHub actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,57 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: CI
+    runs-on: ubuntu-18.04
+    steps:
+
+    - name: Set up Go 1.13
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.13
+      id: go
+
+    - name: Setup Go binary path
+      shell: bash
+      run: |
+        echo "::set-env name=GOPATH::${{ github.workspace }}"
+        echo "::add-path::${{ github.workspace }}/bin"
+
+    - name: Check out code
+      uses: actions/checkout@v2
+      with:
+        path: src/github.com/containerd/containerd.io
+        fetch-depth: 25
+
+    - name: Checkout project
+      uses: actions/checkout@v2
+      with:
+        repository: containerd/project
+        path: src/github.com/containerd/project
+
+    - name: Install dependencies
+      env:
+        GO111MODULE: off
+      run: |
+        go get -u github.com/vbatts/git-validation
+
+    - name: Check DCO/whitespace/commit message
+      env:
+        GITHUB_COMMIT_URL: ${{ github.event.pull_request.commits_url }}
+        DCO_VERBOSITY: "-q"
+        DCO_RANGE: ""
+      working-directory: src/github.com/containerd/containerd.io
+      run: |
+        if [ -z "${GITHUB_COMMIT_URL}" ]; then
+          DCO_RANGE=$(jq -r '.before +".."+ .after' ${GITHUB_EVENT_PATH})
+        else
+          DCO_RANGE=$(curl ${GITHUB_COMMIT_URL} | jq -r '.[0].parents[0].sha +".."+ .[-1].sha')
+        fi
+        ../project/script/validate/dco


### PR DESCRIPTION
For this repository the only thing we had was a DCO check running in
Travis. This moves this step to run as a GitHub Action.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>