### PR TITLE
updating the CRI description

### DIFF
--- a/content/releases.md
+++ b/content/releases.md
@@ -271,7 +271,8 @@ to communicate with a container runtime. This interface is used to manage
 container lifecycles and container images. Currently this API is under
 development and unstable across Kubernetes releases. Each Kubernetes release
 only supports a single version of CRI and the CRI plugin only implements a
-single version of CRI.
+single version of CRI. As of Kubernetes v1.21 kubelet may support two versions
+of CRI, the prior version and a current version.
 
 Each _minor_ release will support one version of CRI and at least one version
 of Kubernetes. Once this API is stable, a _minor_ will be compatible with any

--- a/data/repos.yaml
+++ b/data/repos.yaml
@@ -2,8 +2,8 @@
   description: The main project repo for containerd, including the container runtime
 - name: containerd.io
   description: Assets used to build the containerd website and documentation (i.e. what you're currently reading)
-- name: cri
-  description: The containerd plugin for the [Kubernetes Container Runtime Interface](https://kubernetes.io/docs/setup/cri) (CRI)
+- name: containerd
+  description: As of containerd 1.5 the containerd plugin for the [Kubernetes Container Runtime Interface](https://kubernetes.io/docs/setup/cri) (CRI) has been merged into containerd.
 - name: project
   description: Utilities used across containerd repositories, such as scripts, common files, and core documents
 - name: ttrpc


### PR DESCRIPTION
Reflecting in the docs that CRI is now merged.. 

Also since we had a statement about kubelet only supporting 1 version of CRI .. I felt we needed to update that to describe the change to v1.21 of kubelet.

Signed-off-by: Mike Brown <brownwm@us.ibm.com>