### PR TITLE
Fix release query to get latest releases

### DIFF
--- a/layouts/shortcodes/releases.html
+++ b/layouts/shortcodes/releases.html
@@ -1,4 +1,4 @@
-{{- $releasesUrl := "https://api.github.com/repos/containerd/containerd/releases?per_page=100" }}
+{{- $releasesUrl := "https://api.github.com/repos/containerd/containerd/releases?per_page=50&page=1" }}
 {{- $downloadUrl := "https://github.com/containerd/containerd/releases/download" }}
 {{- $releases    := getJSON $releasesUrl }}
 {{- $latest      := .Site.Params.versions.latest }}


### PR DESCRIPTION
Let's only show the last 50 releases as we really don't need to show 100
of them, with many of them being out of service/very old. Also, adding
the page number seems to have fixed the problem that it wasn't showing
the very latest releases? Or maybe it was a cache issue? We'll know next
time we update a release :)

Signed-off-by: Phil Estes <estesp@amazon.com>