### PR TITLE
Use Sphinx to manage docs/latest/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,11 +21,17 @@ serve:
 		--buildFuture \
 		--disableFastRender
 
-production-build:
+public/docs/latest:
+	rm -fr containerd # seems Netlify is caching this directory.
+	git clone --depth 1 https://github.com/containerd/containerd.git containerd
+	mv sphinx/* containerd/docs/
+	sphinx-build containerd/docs public/docs/latest
+
+production-build: public/docs/latest
 	hugo \
 	--minify
 
-preview-build:
+preview-build: public/docs/latest
 	hugo \
 		--baseURL $(DEPLOY_PRIME_URL) \
 		--buildDrafts \

--- a/netlify.toml
+++ b/netlify.toml
@@ -4,6 +4,7 @@ command = "make production-build"
 
 [build.environment]
 HUGO_VERSION = "0.65.3"
+PYTHON_VERSION = "3.7"
 
 [context.deploy-preview]
 command = "make preview-build"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+Sphinx == 4.4.0
+furo == 2022.3.4
+myst-parser == 0.17.0

--- a/sphinx/conf.py
+++ b/sphinx/conf.py
@@ -1,0 +1,16 @@
+project = 'containerd'
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+html_static_path = ['_static']
+
+# Same as our License header.
+copyright = 'The contained Authors'
+author = 'The containerd Authors'
+
+# MyST (Markedly Structured Text) is a superset of CommonMark.
+# https://myst-parser.readthedocs.io/en/latest/
+extensions = [ 'myst_parser' ]
+
+# Uses Furo.
+# https://github.com/pradyunsg/furo
+html_theme = 'furo'

--- a/sphinx/index.md
+++ b/sphinx/index.md
@@ -1,0 +1,43 @@
+# containerd
+
+TBD
+
+```{toctree}
+:hidden:
+:caption: Getting Started
+ops.md
+content-flow.md
+garbage-collection.md
+hosts.md
+managed-opt.md
+stream-processors.md
+```
+
+```{toctree}
+:hidden:
+:caption: Advanced
+namespaces.md
+remote-snapshotter.md
+tracing.md
+rootless.md
+```
+
+```{toctree}
+:hidden:
+:caption: Developing containerd client
+getting-started.md
+client-opts.md
+```
+
+```{toctree}
+:hidden:
+:caption: CRI
+cri/config.md
+cri/crictl.md
+cri/decryption.md
+cri/installation.md
+cri/proposal.md
+cri/registry.md
+cri/testing.md
+cri/architecture.md
+```


### PR DESCRIPTION
This commit adds https://containerd.io/docs/latest/, based on
github.com/containerd/containerd's docs directory.

We would need docs/1.6/, docs/1.5/, ... eventually. But for now
we can start from the tip of the main branch.
