### PR TITLE
Ensure analytics is enabled in production only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ resources/
 # Link checker assets
 bin/
 tmp/
+.hugo_build.lock
+package-lock.json

--- a/Makefile
+++ b/Makefile
@@ -12,24 +12,24 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
+DEPLOY_PRIME_URL?=/
+HUGO?=npx hugo
+
 clean:
-	rm -rf public resources
+	rm -rf public/* resources
 
 serve:
-	hugo server \
-		--buildDrafts \
-		--buildFuture \
-		--disableFastRender
+	$(HUGO) serve -DEF --disableFastRender
+
+build:
+	$(HUGO) --cleanDestinationDir -e dev -DEF
 
 production-build:
-	hugo \
-	--minify
+	$(HUGO) --cleanDestinationDir
+# --minify
 
 preview-build:
-	hugo \
-		--baseURL $(DEPLOY_PRIME_URL) \
-		--buildDrafts \
-		--buildFuture
+	$(HUGO) --cleanDestinationDir -e dev -DEF --baseURL $(DEPLOY_PRIME_URL)
 
 install-link-checker:
 	curl https://raw.githubusercontent.com/wjdp/htmltest/master/godownloader.sh | bash

--- a/config.toml
+++ b/config.toml
@@ -9,7 +9,6 @@ theme = "containerd"
 
 [params]
 description        = "An industry-standard container runtime with an emphasis on simplicity, robustness, and portability"
-googleAnalyticsId  = "UA-71407002-1"
 githubRepo         = "containerd/containerd"
 twitterHandle      = "containerd"
 slackChannel       = "https://slack.containerd.io/"

--- a/netlify.toml
+++ b/netlify.toml
@@ -2,11 +2,11 @@
 publish = "public"
 command = "make production-build"
 
-[build.environment]
-HUGO_VERSION = "0.65.3"
-
 [context.deploy-preview]
 command = "make preview-build"
 
 [context.branch-deploy]
 command = "make preview-build"
+
+[context.production.environment]
+HUGO_ENV = "production"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "devDependencies": {
-    "bulma": "^0.7.1"
+    "bulma": "^0.7.1",
+    "hugo-extended": "0.65.3"
   }
 }

--- a/themes/containerd/layouts/partials/google-analytics.html
+++ b/themes/containerd/layouts/partials/google-analytics.html
@@ -1,11 +1,9 @@
-{{- $googleAnalyticsId := .Site.Params.googleAnalyticsId }}
+{{/* Global site tag (gtag.js) - Google Analytics */ -}}
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-KGB7V28PEJ"></script>
 <script>
-(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
 
-ga('create', '{{ $googleAnalyticsId }}', 'auto');
-ga('send', 'pageview');
+  gtag('config', 'G-KGB7V28PEJ');
 </script>
-    

--- a/themes/containerd/layouts/partials/google-analytics.html
+++ b/themes/containerd/layouts/partials/google-analytics.html
@@ -1,3 +1,5 @@
+{{ $isProduction  := eq hugo.Environment "production" -}}
+{{ if $isProduction -}}
 {{/* Global site tag (gtag.js) - Google Analytics */ -}}
 <script async src="https://www.googletagmanager.com/gtag/js?id=G-KGB7V28PEJ"></script>
 <script>
@@ -7,3 +9,4 @@
 
   gtag('config', 'G-KGB7V28PEJ');
 </script>
+{{- end -}}


### PR DESCRIPTION
- **Depends on** #135, which needs to be **merged first**
- Contributes to #133

### Test

- View the page source of https://deploy-preview-136--containerd-io.netlify.app/, and you'll notice that the page contains only the injected `gtag.js` code snippet.