### PR TITLE
[DO NOT MERGE] testing updated Netlify build image

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -8,7 +8,7 @@ disableKinds = ["taxonomy", "taxonomyTerm"]
 theme = "containerd"
 
 [params]
-description        = "An industry-standard container runtime with an emphasis on simplicity, robustness, and portability"
+description        = "An industry-standard container runtime with an emphasis on simplicity, robustness, and portability and testing the latest Netlify build image"
 googleAnalyticsId  = "UA-71407002-1"
 githubRepo         = "containerd/containerd"
 twitterHandle      = "containerd"


### PR DESCRIPTION
do not merge: testing Netlify build after switching to 20.04 build image
as Xenial is being deprecated by Netlify.

Signed-off-by: Phil Estes <estesp@amazon.com>