### PR TITLE
Update GitHub actions packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     steps:
 
     - name: Check out code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         path: src/github.com/containerd/containerd.io
         fetch-depth: 25
 
-    - uses: containerd/project-checks@v1.0.1
+    - uses: containerd/project-checks@v1.1.0
       with:
         working-directory: src/github.com/containerd/containerd.io

--- a/.github/workflows/sync-releases.yml
+++ b/.github/workflows/sync-releases.yml
@@ -9,7 +9,7 @@ jobs:
   update-releasesmd:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Update dependencies
         id: vars
         run: |


### PR DESCRIPTION
Update actions/checkout from v2 to v3.
Update containerd/project-checks from v1.0.1 to v1.1.0.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>