### PR TITLE
Remove "Check back soon"

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -4,13 +4,11 @@ short: Overview
 weight: 1
 ---
 
-{{< warning >}}
-The containerd documentation is currently under construction. Check back soon for updates!
-{{< /warning >}}
-
 Welcome to the containerd documentation! This document contains some basic project-level information about containerd.
 
 If you'd like to get started running containerd locally on your machine, see the [Getting started](https://github.com/containerd/containerd/blob/main/docs/getting-started.md) guide.
+
+See also other docs: https://github.com/containerd/containerd/tree/main/docs
 
 ## Repositories
 


### PR DESCRIPTION
It doesn't make much sense to retain "Check back soon" for more than four years.
