### PR TITLE
Force release JSON to update each time we update the site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -42,3 +42,7 @@ sizes = [300,400,600,700]
 [[params.fonts]]
 name = "Fira Mono"
 sizes = [300,400,600,700]
+
+[caches]
+  [caches.getjson]
+    maxAge = "24h"


### PR DESCRIPTION
Currently the downloads list on the website is only re-generated if Hugo can't find a cache of the page in Netlify, which seems to persist for {a long time} unless a change is made to the downloads page itself.

Setting the cache to 24 hours for the "getJSON" call so that each time we update the release it should force a re-render of the downloads list.

Signed-off-by: Phil Estes <estesp@amazon.com>