### PR TITLE
Upgrade Hugo from 0.65.3 to 0.111.3

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,7 @@ publish = "public"
 command = "make production-build"
 
 [build.environment]
-HUGO_VERSION = "0.65.3"
+HUGO_VERSION = "0.111.3"
 
 [context.deploy-preview]
 command = "make preview-build"


### PR DESCRIPTION
We don't need particular features/fixes, but asking others to install Hugo from 2022 doesn't make much sense.