### PR TITLE
add npm install . to README instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,13 @@ The containerd site is built using the [Hugo](https://gohugo.io) static site gen
 
 In order to run the site locally, you'll need to install the version of Hugo specified using the `HUGO_VERSION` environment variable in [`netlify.toml`](netlify.toml). Instructions can be found in the [official Hugo documentation](https://gohugo.io/getting-started/installing/).
 
-Once you have the proper Hugo version installed, run:
+Once you have the proper Hugo version installed, install this package and its dependencies with:
+
+```shell
+npm install .
+```
+
+Finally, run:
 
 ```shell
 make serve


### PR DESCRIPTION
ran into this issue when getting started:

```
ERROR TOCSS: failed to transform "sass/style.sass" (text/x-sass): "/Users/haddscot/workplace/containerd.io/themes/containerd/assets/sass/style.sass:10:1": File to import not found or unreadable: bulma/sass/utilities/initial-variables.
```

spent a little more time than I would have liked figuring out that I needed to `npm install .`

hopefully this saves the next guy a little bit of time