### PR TITLE
Fix relative links for containerd docs

### DIFF
--- a/.github/workflows/sync-releases.yml
+++ b/.github/workflows/sync-releases.yml
@@ -18,6 +18,7 @@ jobs:
           sed -i'' 's,| \[api/\](api),| \[gRPC API\](#grpc),' content/releases.md
           sed -i'' 's, See \[api/\](api) for details.,,' content/releases.md
           sed -i'' 's,^### GRPC API,### GRPC API {#grpc},' content/releases.md
+          sed -i'' 's,\./docs/,https://github.com/containerd/containerd/blob/main/docs/,' content/releases.md
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
Substitute the relative links (relative to the containerd repo) with absolute links that point at the main branch of the containerd repo.