### PR TITLE
docs: add containerd 2.3 release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -14,3 +14,7 @@
 	path = containerd-main
 	url = https://github.com/containerd/containerd.git
 	branch = main
+[submodule "containerd-2.3"]
+	path = containerd-2.3
+	url = https://github.com/containerd/containerd.git
+	branch = release/2.3

--- a/config.toml
+++ b/config.toml
@@ -33,9 +33,9 @@ features = [
 ]
 
 [params.versions]
-latest = "2.2.0"
-latestdir = "2.2"
-all = ["2.2", "2.1", "1.7", "main"]
+latest = "2.3.0"
+latestdir = "2.3"
+all = ["2.3", "2.2", "2.1", "1.7", "main"]
 
 [[params.fonts]]
 name = "Lato"

--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -17,6 +17,7 @@ The containerd project is encapsulated in a variety of GitHub repositories; see 
 ## Getting Started
 
 - [main](main/getting-started/)
+- [2.3.x](2.3/getting-started/)
 - [2.2.x](2.2/getting-started/)
 - [2.1.x](2.1/getting-started/)
 - [1.7.x](1.7/getting-started/)

--- a/netlify.toml
+++ b/netlify.toml
@@ -28,5 +28,5 @@ status = 302
 
 [[redirects]]
 from = "/docs/latest/*"
-to = "/docs/2.2/:splat"
+to = "/docs/2.3/:splat"
 status = 302


### PR DESCRIPTION
Add documentation for the containerd 2.3 release, set it as the latest version, and update relevant redirects and links.

- Add git submodule for containerd 2.3 pointing to release/2.3.
- Update config.toml to set 2.3 as latest and add to versions list.
- Update netlify.toml to redirect /docs/latest/* to /docs/2.3/.
- Update content/docs/_index.md with link to 2.3.x.

Tested by running hugo to verify the site builds without errors.

Assisted-by: Antigravity